### PR TITLE
edu.stanford.Almond.json: Use GNOME 3.38 runtime

### DIFF
--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "edu.stanford.Almond",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.34",
+    "runtime-version" : "3.38",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.openjdk11",


### PR DESCRIPTION
GNOME 3.34 runtime is deprecated