### PR TITLE
Update runtime to gnome 40

### DIFF
--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "edu.stanford.Almond",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.38",
+    "runtime-version" : "40",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.node12"


### PR DESCRIPTION
3.38 is deprecated.
The app itself seems to build & work fine with the updated runtime.
